### PR TITLE
py_jsにtsの簡単な説明を追記, アンケートをSafariでも表示, ダークモードのcss調整

### DIFF
--- a/markdown/mis_python_javascript.html
+++ b/markdown/mis_python_javascript.html
@@ -1808,6 +1808,7 @@ let a: boolean = true
 let b: null = null
 let c: { x: number, y: number } = { x: 20, y: 40 }
 let d: (x: number) =&gt; void = (x: number) =&gt; { console.log(x) }  // numberを受け取ってundefinedを返す関数型
+let e: number[] = []  // 数値の配列
 
 // 型指定で毎回 { x: number, y: number } みたいに書くのは長くてつらいため、
 // interface文で型に名前を付けられる
@@ -1842,7 +1843,8 @@ if (typeof x === &quot;number&quot;) {
     console.log(x + 20)  // 問題なし
 }
 
-// 他にも extends/inferとかいろいろあるが、</code></pre>
+// 他にも extends/infer, typeof, keyof, ...といろいろあるが、軽く使う分には必要ない。
+</code></pre>
 </li>
 </ul>
 <p><div class="questionnaire" id="型付けしよう">

--- a/markdown/mis_python_javascript.html
+++ b/markdown/mis_python_javascript.html
@@ -1269,6 +1269,10 @@ body.dark .markdown-body table td {
 
 body.dark .markdown-body a {
     color: #cee5ff;
+}
+
+body.dark .connection-status-box {
+    color: black;
 }</style>
 </head>
 <body>
@@ -1278,6 +1282,12 @@ body.dark .markdown-body a {
 <button class="light-mode-button">ライトモードへ</button>
 <button class="dark-mode-button">ダークモードへ</button>
 </p>
+<p>更新履歴:</p>
+<ul>
+<li>19/05/09 型付けしよう &gt; TypeScriptを使う にTypeScriptの文法の簡単な説明を追記</li>
+<li>19/05/01 Node.jsのバージョンにLTSを推奨</li>
+</ul>
+<p>目次:</p>
 <ul>
 <li><a href="#python-javascript%E3%81%AE%E5%A7%8B%E3%82%81%E6%96%B9">Python, JavaScriptの始め方</a></li>
 <li><a href="#%E3%81%AF%E3%81%98%E3%82%81%E3%81%AB">はじめに</a><ul>
@@ -1761,8 +1771,6 @@ undefined
 <ul>
 <li><p>JavaScriptではTypeScriptを使って型付けできます。TypeScriptは、JavaScriptに型付け用の文法を足した言語で、JavaScriptに変換されてから実行されます。</p>
 </li>
-<li><p><a href="https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html">公式サイトのチュートリアル</a>を見た後、<a href="https://qiita.com/uhyo/items/da21e2b3c10c8a03952f">TypeScriptの型初級</a>らへんを見るとよいと思います。（TypeScriptはJavaScriptさえ分かっていれば学習コストが低いことが特徴なので、とりあえずは軽く使ってみて、興味が出たらTypeScriptの型初級を読むといいです。）</p>
-</li>
 <li><p><a href="http://www.typescriptlang.org/play/">TypeScriptの公式サイトのPlayground</a>ではブラウザ上で簡単にTypeScriptを試せます。</p>
 </li>
 <li><p>Node.jsでTypeScriptを使う場合、<code>ts-node</code>が便利です。
@@ -1778,6 +1786,63 @@ npx tsc --init  # TypeScriptの初期化。tsconfig.jsonが生成される。</c
 <p><code>main.ts</code>のようなファイルを作り、コードを書き、コマンドプロンプト（ターミナル）上で<code>npx tsc</code>と打てば、TypeScriptからJavaScriptへ変換されます。</p>
 </li>
 <li><p>TypeScriptでは、変換先のJavaScriptのバージョンが低いときJavaScriptのいくつかの最新の機能（Arrayの関数やMapなど）を使えません。<code>tsconfig.json</code>の<code>&quot;target&quot;</code>を<code>&quot;ES2017&quot;</code>とかにすれば使えるようになります。</p>
+</li>
+<li><p>TypeScriptはJavaScriptとほとんど同じです。最低限覚えるべき文法を記しておきます。細かい使い方はサンプルプログラムを見てください。これを読んだら、次に<a href="https://qiita.com/uhyo/items/da21e2b3c10c8a03952f">TypeScriptの型初級</a>を見ることをお勧めします。（TypeScriptはJavaScriptさえ分かっていれば学習コストが低いことが特徴なので、とりあえずは軽く使ってみて、興味が出たらTypeScriptの型初級を読むといいです。）</p>
+<pre><code class="language-typescript">// 変数はつねに1つの型を持つ。変数の型は最初に代入された値の型によって決まる。
+let x = 20  // xはnumber型になる
+x = &quot;foo&quot;   // JavaScriptではこれは許されるが、TypeScriptではコンパイルエラー。
+
+// 明示的に変数の型を指定できる
+let y: number = 20  // 変数の型を指定して、同時に初期値を代入
+let z: number  // 変数を型を指定して宣言
+
+// 関数の引数と返り値の型を以下のように指定できる
+const f = (x: number, y: string): string =&gt; {  // numberとstringを受け取ってstringを返す
+    return x + y;
+}
+
+console.log(f(20, &quot;foo&quot;).length)  // fの使用例
+
+// 型には他に以下のようなものが存在する
+let a: boolean = true
+let b: null = null
+let c: { x: number, y: number } = { x: 20, y: 40 }
+let d: (x: number) =&gt; void = (x: number) =&gt; { console.log(x) }  // numberを受け取ってundefinedを返す関数型
+
+// 型指定で毎回 { x: number, y: number } みたいに書くのは長くてつらいため、
+// interface文で型に名前を付けられる
+interface I {
+    x: number;
+    y: number;
+}
+let d: I = { x: 20, y: 40 }
+
+// any型の変数はTypeScriptの型チェックから無視され、どんな操作も可能になる。
+// asでキャストできる。anyは危険なため、本当に必要な時にしか使うべきでない。
+console.log(undefined.foo)           // これはコンパイルエラーになる
+console.log((undefined as any).foo)  // これはコンパイルはできるが実行時に TypeError: Cannot read property &#39;foo&#39; of undefined
+
+// ファイル外（scriptタグの埋め込みなど）で定義された変数は、TypeScriptでは
+// 使おうとしても存在しないといわれてコンパイルエラーになるため、declare文が必要。
+// declare let, declare const, declare class, ... を使える。
+// あるいは、型定義ファイルというdeclare文を使ったファイルを別途用意する。
+declare const someLibrary: any  // 変数 someLibrary が any型でグローバルに存在すると宣言
+console.log(someLibrary)  // 変数 someLibrary を使えるようになった
+
+// CommonJSの require() を使う場合、const x = require(&quot;foo&quot;) のように書くとTypeScript
+// から認識されない。CommonJS用の文法 import x = require(&quot;foo&quot;) を使う必要がある。
+import fs = require(&quot;fs&quot;)
+
+// x | y で型xまたは型yである型を定義できる。
+// そのような型の変数を値を使う場合、先にif文で型をチェックしておく必要がある。
+let x: number | null = null
+console.log(x + 20)  // コンパイルエラー: Object is possibly &#39;null&#39;.
+if (typeof x === &quot;number&quot;) {
+    // このif文内ではxの型が一時的に number | null から number に変わる
+    console.log(x + 20)  // 問題なし
+}
+
+// 他にも extends/inferとかいろいろあるが、</code></pre>
 </li>
 </ul>
 <p><div class="questionnaire" id="型付けしよう">
@@ -1948,7 +2013,7 @@ app.listen(port, () =&gt; console.log(&quot;Listening on port &quot; + port));</
 </ul>
 <h2 id="typesとは何か">@typesとは何か</h2>
 <ul>
-<li>npmにおいて、&quot;@A/B&quot;という名前のパッケージ名は、&quot;ユーザーAが公開しているパッケージB&quot;という意味。<a href="https://www.npmjs.com/~types">@types</a>は<a href="https://github.com/DefinitelyTyped/DefinitelyTyped">Definitely Typed</a>という団体が管理している。</li>
+<li>npmにおいて、&quot;@A/B&quot;という名前のパッケージ名は、&quot;ユーザーAが公開しているパッケージB&quot;という意味。<a href="https://www.npmjs.com/~types">@types</a>は<a href="https://github.com/DefinitelyTyped/DefinitelyTyped">Definitely Typed</a>という団体が管理していて、TypeScriptの型定義ファイルをまとめている。</li>
 </ul>
 <p><div class="questionnaire" id="サンプルプログラム1">
 <section class="questionnaire__outline">

--- a/markdown/mis_python_javascript.html
+++ b/markdown/mis_python_javascript.html
@@ -1252,7 +1252,6 @@ body.dark .hljs-meta {
 }
 
 body.dark .markdown-body pre {
-    border: white 1px solid;
     background: black;
     padding: 0;
 }
@@ -1273,6 +1272,12 @@ body.dark .markdown-body a {
 
 body.dark .connection-status-box {
     color: black;
+}
+
+body.dark .markdown-body code {
+    border: #ababab 1px solid;
+    border-radius: 4px;
+    background: black;
 }</style>
 </head>
 <body>
@@ -1833,6 +1838,9 @@ console.log(someLibrary)  // 変数 someLibrary を使えるようになった
 // CommonJSの require() を使う場合、const x = require(&quot;foo&quot;) のように書くとTypeScript
 // から認識されない。CommonJS用の文法 import x = require(&quot;foo&quot;) を使う必要がある。
 import fs = require(&quot;fs&quot;)
+
+// ES6の import はJavaScriptと同じ。
+import fs from &quot;fs&quot;
 
 // x | y で型xまたは型yである型を定義できる。
 // そのような型の変数を値を使う場合、先にif文で型をチェックしておく必要がある。
@@ -2696,7 +2704,8 @@ Array.prototype.forEach.call(document.getElementsByClassName("questionnaire"), f
     // IEとかならアンケートを表示しない
     if (window.platform.name !== "Chrome" &&
         window.platform.name !== "Firefox" &&
-        window.platform.name !== "Microsoft Edge") {
+        window.platform.name !== "Microsoft Edge" &&
+        window.platform.name !== "Safari") {
         // Safariは動作確認できないのでIEと同じ処理
         questionnaire.innerHTML = "";
         return;

--- a/markdown/py_js_src/src/view/dark_theme.css
+++ b/markdown/py_js_src/src/view/dark_theme.css
@@ -21,3 +21,7 @@ body.dark .markdown-body table td {
 body.dark .markdown-body a {
     color: #cee5ff;
 }
+
+body.dark .connection-status-box {
+    color: black;
+}

--- a/markdown/py_js_src/src/view/dark_theme.css
+++ b/markdown/py_js_src/src/view/dark_theme.css
@@ -3,7 +3,6 @@ body.dark {
 }
 
 body.dark .markdown-body pre {
-    border: white 1px solid;
     background: black;
     padding: 0;
 }
@@ -24,4 +23,10 @@ body.dark .markdown-body a {
 
 body.dark .connection-status-box {
     color: black;
+}
+
+body.dark .markdown-body code {
+    border: #ababab 1px solid;
+    border-radius: 4px;
+    background: black;
 }

--- a/markdown/py_js_src/src/view/mis_python_javascript.md
+++ b/markdown/py_js_src/src/view/mis_python_javascript.md
@@ -440,6 +440,9 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
   // から認識されない。CommonJS用の文法 import x = require("foo") を使う必要がある。
   import fs = require("fs")
 
+  // ES6の import はJavaScriptと同じ。
+  import fs from "fs"
+
   // x | y で型xまたは型yである型を定義できる。
   // そのような型の変数を値を使う場合、先にif文で型をチェックしておく必要がある。
   let x: number | null = null

--- a/markdown/py_js_src/src/view/mis_python_javascript.md
+++ b/markdown/py_js_src/src/view/mis_python_javascript.md
@@ -3,6 +3,12 @@ Python, JavaScriptの始め方
 
 *CHANGE_THEME!*
 
+更新履歴:
+- 19/05/09 型付けしよう > TypeScriptを使う にTypeScriptの文法の簡単な説明を追記
+- 19/05/01 Node.jsのバージョンにLTSを推奨
+
+目次:
+
 - [Python, JavaScriptの始め方](#python-javascript%E3%81%AE%E5%A7%8B%E3%82%81%E6%96%B9)
 - [はじめに](#%E3%81%AF%E3%81%98%E3%82%81%E3%81%AB)
   - [Pythonとは](#python%E3%81%A8%E3%81%AF)
@@ -370,7 +376,6 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
 
 ## TypeScriptを使う
 - JavaScriptではTypeScriptを使って型付けできます。TypeScriptは、JavaScriptに型付け用の文法を足した言語で、JavaScriptに変換されてから実行されます。
-- [公式サイトのチュートリアル](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)を見た後、[TypeScriptの型初級](https://qiita.com/uhyo/items/da21e2b3c10c8a03952f)らへんを見るとよいと思います。（TypeScriptはJavaScriptさえ分かっていれば学習コストが低いことが特徴なので、とりあえずは軽く使ってみて、興味が出たらTypeScriptの型初級を読むといいです。）
 - [TypeScriptの公式サイトのPlayground](http://www.typescriptlang.org/play/)ではブラウザ上で簡単にTypeScriptを試せます。
 - Node.jsでTypeScriptを使う場合、`ts-node`が便利です。
   コマンドプロンプト（ターミナル）上で`npm install -g ts-node typescript`と打つとts-nodeがインストールされます（ts-nodeの使用にはtypescriptのインストールも必要）。あとは、`ts-node ファイル名`と打てば、TypeScriptのファイルを実行できるはずです。
@@ -387,6 +392,64 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
   ```
   `main.ts`のようなファイルを作り、コードを書き、コマンドプロンプト（ターミナル）上で`npx tsc`と打てば、TypeScriptからJavaScriptへ変換されます。
 - TypeScriptでは、変換先のJavaScriptのバージョンが低いときJavaScriptのいくつかの最新の機能（Arrayの関数やMapなど）を使えません。`tsconfig.json`の`"target"`を`"ES2017"`とかにすれば使えるようになります。
+- TypeScriptはJavaScriptとほとんど同じです。最低限覚えるべき文法を記しておきます。細かい使い方はサンプルプログラムを見てください。これを読んだら、次に[TypeScriptの型初級](https://qiita.com/uhyo/items/da21e2b3c10c8a03952f)を見ることをお勧めします。（TypeScriptはJavaScriptさえ分かっていれば学習コストが低いことが特徴なので、とりあえずは軽く使ってみて、興味が出たらTypeScriptの型初級を読むといいです。）
+  ```typescript
+  // 変数はつねに1つの型を持つ。変数の型は最初に代入された値の型によって決まる。
+  let x = 20  // xはnumber型になる
+  x = "foo"   // JavaScriptではこれは許されるが、TypeScriptではコンパイルエラー。
+
+  // 明示的に変数の型を指定できる
+  let y: number = 20  // 変数の型を指定して、同時に初期値を代入
+  let z: number  // 変数を型を指定して宣言
+
+  // 関数の引数と返り値の型を以下のように指定できる
+  const f = (x: number, y: string): string => {  // numberとstringを受け取ってstringを返す
+      return x + y;
+  }
+
+  console.log(f(20, "foo").length)  // fの使用例
+
+  // 型には他に以下のようなものが存在する
+  let a: boolean = true
+  let b: null = null
+  let c: { x: number, y: number } = { x: 20, y: 40 }
+  let d: (x: number) => void = (x: number) => { console.log(x) }  // numberを受け取ってundefinedを返す関数型
+
+  // 型指定で毎回 { x: number, y: number } みたいに書くのは長くてつらいため、
+  // interface文で型に名前を付けられる
+  interface I {
+      x: number;
+      y: number;
+  }
+  let d: I = { x: 20, y: 40 }
+
+  // any型の変数はTypeScriptの型チェックから無視され、どんな操作も可能になる。
+  // asでキャストできる。anyは危険なため、本当に必要な時にしか使うべきでない。
+  console.log(undefined.foo)           // これはコンパイルエラーになる
+  console.log((undefined as any).foo)  // これはコンパイルはできるが実行時に TypeError: Cannot read property 'foo' of undefined
+
+  // ファイル外（scriptタグの埋め込みなど）で定義された変数は、TypeScriptでは
+  // 使おうとしても存在しないといわれてコンパイルエラーになるため、declare文が必要。
+  // declare let, declare const, declare class, ... を使える。
+  // あるいは、型定義ファイルというdeclare文を使ったファイルを別途用意する。
+  declare const someLibrary: any  // 変数 someLibrary が any型でグローバルに存在すると宣言
+  console.log(someLibrary)  // 変数 someLibrary を使えるようになった
+
+  // CommonJSの require() を使う場合、const x = require("foo") のように書くとTypeScript
+  // から認識されない。CommonJS用の文法 import x = require("foo") を使う必要がある。
+  import fs = require("fs")
+
+  // x | y で型xまたは型yである型を定義できる。
+  // そのような型の変数を値を使う場合、先にif文で型をチェックしておく必要がある。
+  let x: number | null = null
+  console.log(x + 20)  // コンパイルエラー: Object is possibly 'null'.
+  if (typeof x === "number") {
+      // このif文内ではxの型が一時的に number | null から number に変わる
+      console.log(x + 20)  // 問題なし
+  }
+
+  // 他にも extends/inferとかいろいろあるが、
+  ```
 
 *QUESTIONNAIRE! 型付けしよう*
 
@@ -528,7 +591,7 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
 - npmなら、weekly downloads で人気度を確認できる。pypiはダウンロード数を公開していないので、ライブラリのGitHubページのスター数を見るとよい。
 
 ## @typesとは何か
-- npmにおいて、"@A/B"という名前のパッケージ名は、"ユーザーAが公開しているパッケージB"という意味。[@types](https://www.npmjs.com/~types)は[Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped)という団体が管理している。
+- npmにおいて、"@A/B"という名前のパッケージ名は、"ユーザーAが公開しているパッケージB"という意味。[@types](https://www.npmjs.com/~types)は[Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped)という団体が管理していて、TypeScriptの型定義ファイルをまとめている。
 
 *QUESTIONNAIRE! サンプルプログラム1*
 

--- a/markdown/py_js_src/src/view/mis_python_javascript.md
+++ b/markdown/py_js_src/src/view/mis_python_javascript.md
@@ -414,6 +414,7 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
   let b: null = null
   let c: { x: number, y: number } = { x: 20, y: 40 }
   let d: (x: number) => void = (x: number) => { console.log(x) }  // numberを受け取ってundefinedを返す関数型
+  let e: number[] = []  // 数値の配列
 
   // 型指定で毎回 { x: number, y: number } みたいに書くのは長くてつらいため、
   // interface文で型に名前を付けられる
@@ -448,7 +449,8 @@ PythonもJavaScriptも活発に開発されていて、アップデートが速�
       console.log(x + 20)  // 問題なし
   }
 
-  // 他にも extends/inferとかいろいろあるが、
+  // 他にも extends/infer, typeof, keyof, ...といろいろあるが、軽く使う分には必要ない。
+
   ```
 
 *QUESTIONNAIRE! 型付けしよう*

--- a/markdown/py_js_src/src/view/template.ts
+++ b/markdown/py_js_src/src/view/template.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-// hogehoge
+
 export const htmlTemplate = (article: string) =>
 `<!DOCTYPE html>
 <html lang="ja">

--- a/markdown/py_js_src/src/web/questionnaire.ts
+++ b/markdown/py_js_src/src/web/questionnaire.ts
@@ -67,7 +67,8 @@ Array.prototype.forEach.call(document.getElementsByClassName("questionnaire"), (
     // IEとかならアンケートを表示しない
     if ((window as any).platform.name !== "Chrome" &&
             (window as any).platform.name !== "Firefox" &&
-            (window as any).platform.name !== "Microsoft Edge") {
+            (window as any).platform.name !== "Microsoft Edge" &&
+            (window as any).platform.name !== "Safari") {
         // Safariは動作確認できないのでIEと同じ処理
         questionnaire.innerHTML = "";
         return;


### PR DESCRIPTION
- ダークモードでのインラインコードとアンケートのcssを修正
- Safariで動作確認できたため、アンケートをSafariでも表示（今まではSafariとかの場合は非表示にしていた）
- TypeScriptの説明が少なすぎたため追記
